### PR TITLE
add support for multiple smtp recipient addresses

### DIFF
--- a/src/controller/motion/motion.controller.js
+++ b/src/controller/motion/motion.controller.js
@@ -411,14 +411,19 @@ export default class MotionController {
           let name;
 
           if (mailToCamera) {
-            log.info(`New message: Data (email to): ${JSON.stringify(session.envelope.rcptTo)}`, 'SMTP');
-            name = mailTo;
+            for (const rcptTo of session.envelope.rcptTo) {
+              log.info(`New message: Data (email to): ${JSON.stringify(rcptTo)}`, 'SMTP');
+              name = rcptTo.address.split('@')[0].replace(regex, ' ');
+              await MotionController.handleMotion('motion', name, true, 'smtp');
+            }
+            return;
+
           } else {
             log.info(`New message: Data (email from): ${JSON.stringify(session.envelope.mailFrom)}`, 'SMTP');
             name = mailFrom;
+            return await MotionController.handleMotion('motion', name, true, 'smtp');
           }
 
-          return await MotionController.handleMotion('motion', name, true, 'smtp');
         } else {
           log.info(
             'Email received but can not determine camera name through email adresse(s), checking email body...',


### PR DESCRIPTION
This is especially useful for dual cameras like the Reolink Duo which supports to send smtp with more than one recipient address to trigger motion on both rtsp streams. The Reolink Duo does not support two different smtp setups for the two build-in cameras, so this is the only working solution to get motion detection triggered for both rtsp feeds.

