### PR TITLE
Make fMP4 session shutdown awaitable and idempotent

### DIFF
--- a/server/src/camera/streaming/fmp4-session.ts
+++ b/server/src/camera/streaming/fmp4-session.ts
@@ -17,6 +17,7 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
   readonly onEnded = new ReplaySubject<void>(1);
 
   #hasEnded = false;
+  #shutdownPromise?: Promise<void>;
   #cameraDevice: CameraDevice;
   #logger: LoggerService;
   #source: CameraDeviceSource;
@@ -41,6 +42,14 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
   }
 
   public async startStream(config?: Fmp4SessionOptions): Promise<void> {
+    if (this.#hasEnded || this.#shutdownPromise) {
+      throw new Error('FMP4 session has ended and cannot be restarted.');
+    }
+
+    if (this.#fmp4Stream) {
+      throw new Error('FMP4 session already started.');
+    }
+
     this.#options = {
       ...config,
       input: {
@@ -52,14 +61,6 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
     };
 
     this.#logger.debug('Starting FMP4 session with options:', this.#options);
-
-    if (this.#boxDataSubject.closed) {
-      this.#boxDataSubject = new ReplaySubject<Buffer>(1);
-    }
-
-    if (this.#initSegmentSubject.closed) {
-      this.#initSegmentSubject = new ReplaySubject<Buffer>(1);
-    }
 
     const supportedVideoCodec = new Set<string>();
     for (const videoCodec of this.#options.supportedVideoCodecs ?? []) {
@@ -97,7 +98,7 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
     let initSegment: Buffer | undefined;
     let initSegmentSent = false;
 
-    this.#fmp4Stream = FMP4Stream.create(this.#url, {
+    const fmp4Stream = FMP4Stream.create(this.#url, {
       onData: (data: Buffer, info: FMP4Data) => {
         for (const box of info.boxes) {
           if (box.type === 'ftyp') {
@@ -125,12 +126,11 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
           this.#boxDataSubject.next(data);
         }
       },
-      onClose: async (err?: Error) => {
-        if (err) {
-          await this.#onError(err);
-        } else {
-          await this.#onEnded();
-        }
+      onClose: (err?: Error) => {
+        const shutdown = err ? this.#onError(err) : this.#onEnded();
+        void shutdown.catch((error) => {
+          this.#logger.error('Failed to shut down FMP4 session:', error);
+        });
       },
       boxMode: this.#options.boxMode,
       fragDuration: this.#options.fragDuration,
@@ -149,7 +149,18 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
       },
     });
 
-    await this.#fmp4Stream.start();
+    this.#fmp4Stream = fmp4Stream;
+
+    try {
+      await fmp4Stream.start();
+    } catch (error) {
+      try {
+        await this.#onEnded();
+      } catch (stopError) {
+        this.#logger.error('Failed to clean up FMP4 session after start error:', stopError);
+      }
+      throw error;
+    }
   }
 
   public async *streamBoxes(signal?: AbortSignal): AsyncGenerator<Buffer, void> {
@@ -213,11 +224,12 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
     } finally {
       cleanup();
       endSub.unsubscribe();
+      signal?.removeEventListener('abort', cleanup);
     }
   }
 
   public async stop(): Promise<void> {
-    this.#onEnded();
+    await this.#onEnded();
   }
 
   async #onError(error: Error): Promise<void> {
@@ -225,22 +237,29 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
     await this.#onEnded();
   }
 
-  async #onEnded(): Promise<void> {
-    if (this.#hasEnded) {
-      return;
-    }
+  #onEnded(): Promise<void> {
+    this.#shutdownPromise ??= Promise.resolve().then(() => this.#shutdown());
+    return this.#shutdownPromise;
+  }
 
+  async #shutdown(): Promise<void> {
     this.#hasEnded = true;
 
-    await this.#fmp4Stream?.stop();
+    const fmp4Stream = this.#fmp4Stream;
     this.#fmp4Stream = undefined;
 
-    this.#boxDataSubject.complete();
-    this.#initSegmentSubject.complete();
+    try {
+      await fmp4Stream?.stop();
+    } finally {
+      this.#boxDataSubject.complete();
+      this.#initSegmentSubject.complete();
+      this.onStarted.complete();
+      this.onError.complete();
 
-    this.unsubscribe();
+      this.unsubscribe();
 
-    this.onEnded.next();
-    this.onEnded.complete();
+      this.onEnded.next();
+      this.onEnded.complete();
+    }
   }
 }

--- a/server/test/fmp4-session.test.ts
+++ b/server/test/fmp4-session.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fmp4 = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+vi.mock('node-av/api', () => ({
+  FMP4_CODECS: {
+    H264: 'h264',
+    H265: 'hevc',
+    AV1: 'av1',
+    AAC: 'aac',
+    OPUS: 'opus',
+    FLAC: 'flac',
+  },
+  FMP4Stream: fmp4,
+}));
+
+vi.mock('../src/camera/streaming/node-av-log.js', () => ({
+  setupNodeAvLog: vi.fn(),
+}));
+
+import { Fmp4Session } from '../src/camera/streaming/fmp4-session.js';
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function createSession(): Fmp4Session {
+  const logger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+  };
+  const source = {
+    name: 'main',
+    generateRTSPUrl: vi.fn(() => 'rtsp://camera'),
+  };
+  const cameraDevice = {
+    logger,
+    sources: [source],
+  };
+
+  return new Fmp4Session(cameraDevice as never, source as never);
+}
+
+describe('Fmp4Session lifecycle', () => {
+  beforeEach(() => {
+    fmp4.create.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('awaits one native shutdown for concurrent stop calls', async () => {
+    const shutdown = deferred();
+    const nativeSession = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(() => shutdown.promise),
+    };
+    fmp4.create.mockReturnValue(nativeSession);
+    const session = createSession();
+    await session.startStream();
+
+    let firstFinished = false;
+    let secondFinished = false;
+    const first = session.stop().then(() => {
+      firstFinished = true;
+    });
+    const second = session.stop().then(() => {
+      secondFinished = true;
+    });
+
+    await Promise.resolve();
+    expect(nativeSession.stop).toHaveBeenCalledTimes(1);
+    expect(firstFinished).toBe(false);
+    expect(secondFinished).toBe(false);
+
+    shutdown.resolve();
+    await Promise.all([first, second]);
+    expect(firstFinished).toBe(true);
+    expect(secondFinished).toBe(true);
+  });
+
+  it('cleans up a partially started native session and rethrows the start error', async () => {
+    const startError = new Error('start failed');
+    const nativeSession = {
+      start: vi.fn().mockRejectedValue(startError),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    fmp4.create.mockReturnValue(nativeSession);
+    const session = createSession();
+
+    await expect(session.startStream()).rejects.toBe(startError);
+    expect(nativeSession.stop).toHaveBeenCalledTimes(1);
+    await session.stop();
+    expect(nativeSession.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-enter shutdown when native stop closes synchronously', async () => {
+    let onClose!: () => void;
+    const nativeSession = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn(() => onClose()),
+    };
+    fmp4.create.mockImplementation((_url: string, options: { onClose: () => void }) => {
+      onClose = options.onClose;
+      return nativeSession;
+    });
+    const session = createSession();
+    await session.startStream();
+
+    await session.stop();
+    expect(nativeSession.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the abort listener when a box iterator is closed', async () => {
+    const nativeSession = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    fmp4.create.mockReturnValue(nativeSession);
+    const session = createSession();
+    await session.startStream();
+
+    const abort = new AbortController();
+    const addEventListener = vi.spyOn(abort.signal, 'addEventListener');
+    const removeEventListener = vi.spyOn(abort.signal, 'removeEventListener');
+    const iterator = session.streamBoxes(abort.signal);
+    const pending = iterator.next();
+    await Promise.resolve();
+
+    abort.abort();
+    await expect(pending).resolves.toEqual({ done: true, value: undefined });
+    expect(addEventListener).toHaveBeenCalledWith('abort', expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    await session.stop();
+  });
+
+  it('ends a slow consumer after the queue limit is exceeded', async () => {
+    const nativeSession = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+    };
+    fmp4.create.mockReturnValue(nativeSession);
+    const session = createSession();
+    await session.startStream();
+
+    const options = fmp4.create.mock.calls[0][1];
+    const iterator = session.streamBoxes();
+    const first = iterator.next();
+    await Promise.resolve();
+
+    options.onData(Buffer.from('init'), { boxes: [{ type: 'ftyp' }, { type: 'moov' }] });
+    for (let index = 0; index < 34; index += 1) {
+      options.onData(Buffer.from(`box-${index}`), { boxes: [{ type: 'moof' }] });
+    }
+
+    await expect(first).resolves.toMatchObject({ done: false });
+    await expect(iterator.next()).rejects.toThrow('fMP4 consumer too slow');
+    await session.stop();
+  });
+});


### PR DESCRIPTION
## Summary

- serialize all fMP4 shutdown paths through one shared promise
- await native `node-av` cleanup from `stop()` and startup failures
- prevent restarting an ended or already-started session
- complete session subjects and remove abort listeners during cleanup
- add focused lifecycle regression tests

## Root cause

`Fmp4Session.stop()` did not await cleanup, and the ended flag was set before native shutdown completed. Concurrent stop, error, and `onClose` paths could therefore return while native resources were still being released. Partially failed starts and iterator abort listeners also lacked complete cleanup.

## Impact

This ensures native fMP4 resources are released exactly once and callers can reliably wait for shutdown, reducing the risk of accumulating CPU and memory usage after repeated failures or restarts.

## Validation

- `npm --prefix server run check`
- `npx vitest run test/fmp4-session.test.ts` (5 tests)
- TypeScript compilation completed as part of `build:server`; the subsequent Python type-check remains unavailable locally because generated camera.ui Python SDK modules are not present

Fixes #512