### PR TITLE
Assemble split fMP4 media fragments

### DIFF
--- a/server/src/camera/streaming/fmp4-fragment-assembler.test.ts
+++ b/server/src/camera/streaming/fmp4-fragment-assembler.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { Fmp4FragmentAssembler } from './fmp4-fragment-assembler.js';
+
+describe('Fmp4FragmentAssembler', () => {
+  it('passes through fragments delivered as a combined moof and mdat callback', () => {
+    const assembler = new Fmp4FragmentAssembler();
+    const fragment = Buffer.from('combined');
+
+    expect(assembler.push(fragment, ['moof', 'mdat'])).toBe(fragment);
+  });
+
+  it('combines a split moof and mdat into one media fragment', () => {
+    const assembler = new Fmp4FragmentAssembler();
+
+    expect(assembler.push(Buffer.from('metadata'), ['moof'])).toBeUndefined();
+    expect(assembler.push(Buffer.from('media'), ['mdat'])?.toString()).toBe('metadatamedia');
+  });
+
+  it('does not emit standalone init or media boxes', () => {
+    const assembler = new Fmp4FragmentAssembler();
+
+    expect(assembler.push(Buffer.from('init'), ['moov'])).toBeUndefined();
+    expect(assembler.push(Buffer.from('orphan'), ['mdat'])).toBeUndefined();
+  });
+
+  it('replaces an incomplete fragment when the next moof arrives', () => {
+    const assembler = new Fmp4FragmentAssembler();
+
+    assembler.push(Buffer.from('stale'), ['moof']);
+    assembler.push(Buffer.from('current'), ['moof']);
+
+    expect(assembler.push(Buffer.from('media'), ['mdat'])?.toString()).toBe('currentmedia');
+  });
+});

--- a/server/src/camera/streaming/fmp4-fragment-assembler.ts
+++ b/server/src/camera/streaming/fmp4-fragment-assembler.ts
@@ -1,0 +1,26 @@
+export class Fmp4FragmentAssembler {
+  #pendingMoof?: Buffer;
+
+  public push(data: Buffer, boxTypes: readonly string[]): Buffer | undefined {
+    const hasMoof = boxTypes.includes('moof');
+    const hasMdat = boxTypes.includes('mdat');
+
+    if (hasMoof && hasMdat) {
+      this.#pendingMoof = undefined;
+      return data;
+    }
+
+    if (hasMoof) {
+      this.#pendingMoof = data;
+      return undefined;
+    }
+
+    if (hasMdat && this.#pendingMoof) {
+      const fragment = Buffer.concat([this.#pendingMoof, data]);
+      this.#pendingMoof = undefined;
+      return fragment;
+    }
+
+    return undefined;
+  }
+}

--- a/server/src/camera/streaming/fmp4-session.ts
+++ b/server/src/camera/streaming/fmp4-session.ts
@@ -3,6 +3,7 @@ import { firstValueFrom, ReplaySubject, Subject } from '@camera.ui/sdk';
 import { FMP4_CODECS, FMP4Stream } from 'node-av/api';
 
 import { setupNodeAvLog } from './node-av-log.js';
+import { Fmp4FragmentAssembler } from './fmp4-fragment-assembler.js';
 
 import type { CameraDeviceSource, CameraInput, Fmp4Session as Fmp4SessionInterface, Fmp4SessionOptions, LoggerService, RTSPUrlOptions } from '@camera.ui/sdk';
 import type { FMP4Data } from 'node-av/api';
@@ -97,6 +98,7 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
 
     let initSegment: Buffer | undefined;
     let initSegmentSent = false;
+    const fragmentAssembler = new Fmp4FragmentAssembler();
 
     const fmp4Stream = FMP4Stream.create(this.#url, {
       onData: (data: Buffer, info: FMP4Data) => {
@@ -120,10 +122,16 @@ export class Fmp4Session extends SubscribedPublic implements Fmp4SessionInterfac
           this.onStarted.next();
         }
 
-        // Only send fragments (moof+mdat), not init boxes (ftyp/moov)
-        const isFragment = initSegment && info.boxes.some((box) => box.type === 'moof');
-        if (isFragment) {
-          this.#boxDataSubject.next(data);
+        // node-av may deliver moof and mdat either together or in consecutive callbacks.
+        // Consumers must always receive a complete media fragment containing both boxes.
+        const fragment = initSegment
+          ? fragmentAssembler.push(
+              data,
+              info.boxes.map((box) => box.type),
+            )
+          : undefined;
+        if (fragment) {
+          this.#boxDataSubject.next(fragment);
         }
       },
       onClose: (err?: Error) => {


### PR DESCRIPTION
## Summary

- assemble `moof` and `mdat` boxes when node-av delivers them in consecutive callbacks
- preserve the existing behavior when both boxes arrive together
- ignore orphaned media boxes and replace incomplete pending fragments safely
- add focused regression coverage for all delivery modes

## Root cause

`Fmp4Session` previously forwarded only node-av callbacks containing a `moof` box. Depending on the input path, node-av can emit the matching `mdat` in the following callback. That standalone callback was discarded, so downstream consumers received only the small `moof` metadata box without the encoded media payload.

For HKSV this produced fragments of approximately 804–824 bytes followed by `Unexpected Failure`, while the discarded `mdat` boxes contained several megabytes of video and audio data. This prevented HomeKit Secure Video recordings from being stored.

## Behavior after this change

Consumers always receive a complete `moof+mdat` media fragment. Streams where node-av already emits both boxes together remain unchanged. The correction is generic and does not add any HomeKit- or plugin-specific behavior to camera devices.

## Validation

- `npx vitest run src/camera/streaming/fmp4-fragment-assembler.test.ts`
- 4 focused tests passed
- Prettier passed for the changed files
- `git diff --check` passed

Related investigation: cameraui/plugins#257